### PR TITLE
Feature/selective aruco detect

### DIFF
--- a/autodock_core/launch/autodock_server.launch
+++ b/autodock_core/launch/autodock_server.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="use_fake_clock" default="false" doc="Use this with Caution!!!!"/>
+  <arg name="debug_mode" default="true" doc="Use this to have aruco detections always ON (publish fiducial images always) and other useful visualization markers. Turn OFF for better performance in deployment."/>
   <arg name="autodock_config" default="$(find autodock_core)/configs/mock_robot.yaml"/>
 
   <!-- Danger Zone!!! launch simple dock server with fake clock -->
@@ -9,6 +10,7 @@
     <node pkg="autodock_core" name="simple_autodock" type="simple_autodock.py" 
           args="--server --rosparam --fake_clock" output="screen" respawn="false">
       <rosparam command="load" file="$(arg autodock_config)" />
+      <param name="debug_mode" value="$(arg debug_mode)"/>
     </node>
   </group>
 
@@ -17,6 +19,7 @@
     <node pkg="autodock_core" name="simple_autodock" type="simple_autodock.py" 
           args="--server --rosparam" output="screen" respawn="false">
       <rosparam command="load" file="$(arg autodock_config)" />
+      <param name="debug_mode" value="$(arg debug_mode)"/>
     </node>
   </group>
 

--- a/autodock_core/scripts/autodock_core/autodock_server.py
+++ b/autodock_core/scripts/autodock_core/autodock_server.py
@@ -352,10 +352,10 @@ class AutoDockServer:
         try:
             rospy.wait_for_service('/enable_detections', timeout=3.0)
             resp = self.__enable_detections_srv(detection_state)
-            print("Enable detections response: ", resp.message)
+            rospy.loginfo("Enable detections response: " + resp.message)
             return resp.success
         except rospy.ServiceException as e:
-            print("Service call failed: %s"%e)
+            rospy.logerr("Service call failed: " + str(e))
 
     def __pause_dock_cb(self, msg):
         self.is_pause = msg.data

--- a/autodock_core/scripts/simple_autodock.py
+++ b/autodock_core/scripts/simple_autodock.py
@@ -141,6 +141,7 @@ class AutoDockStateMachine(AutoDockServer):
         """
         rospy.loginfo("Start Docking Action Now")
         self.init_params()
+        self.set_aruco_detections(detection_state=True)
         rospy.sleep(self.sleep_period)
 
         current_retry_count = 0
@@ -156,6 +157,7 @@ class AutoDockStateMachine(AutoDockServer):
             ):
                 self.publish_cmd()
                 self.set_state(DockState.IDLE, "All Success!")
+                self.set_aruco_detections(detection_state=False)
                 return True
 
             # If Dock failed
@@ -164,10 +166,12 @@ class AutoDockStateMachine(AutoDockServer):
 
             # Break from a retry
             if(current_retry_count >= self.cfg.retry_count):
+                self.set_aruco_detections(detection_state=False)
                 break
 
             # check again if it failed because of canceled
             if self.check_cancel():
+                self.set_aruco_detections(detection_state=False)
                 break
 
             # Attempt a Retry
@@ -177,6 +181,7 @@ class AutoDockStateMachine(AutoDockServer):
 
             if not self.do_retry():
                 rospy.logwarn("Not able to retry")
+                self.set_aruco_detections(detection_state=False)
                 break
 
         # Note: will not set_state IDLE here since we will wish to capture

--- a/autodock_core/scripts/simple_autodock.py
+++ b/autodock_core/scripts/simple_autodock.py
@@ -84,6 +84,10 @@ class DefaultAutoDockConfig(AutoDockConfig):
     retry_count = 1             # how many times to retry
     retry_retreat_dis = 0.4     # meters, distance retreat during retry
 
+    # debug state
+    debug_mode = True           # when False selectively turns on aruco detections only
+                                # a valid action is in progress.
+
 
 class AutoDockStateMachine(AutoDockServer):
     """

--- a/autodock_core/scripts/simple_autodock.py
+++ b/autodock_core/scripts/simple_autodock.py
@@ -172,7 +172,7 @@ class AutoDockStateMachine(AutoDockServer):
 
             # Attempt a Retry
             current_retry_count += 1
-            rospy.logwarn("Attemping retry: "
+            rospy.logwarn("Attempting retry: "
                           f"{current_retry_count}/{self.cfg.retry_count}")
 
             if not self.do_retry():
@@ -270,7 +270,7 @@ class AutoDockStateMachine(AutoDockServer):
 
         # start predock loop
         _pose_list = []
-        rospy.loginfo("Both Markers are detected, runnning predock loop")
+        rospy.loginfo("Both Markers are detected, running predock loop")
         while not rospy.is_shutdown():
             if self.check_cancel():
                 return False
@@ -282,7 +282,7 @@ class AutoDockStateMachine(AutoDockServer):
             centre_tf = self.get_centre_of_side_markers()
 
             if centre_tf is None:
-                rospy.logerr("Not detecting two sides marker, exit state")
+                rospy.logerr("Not detecting two side markers, exit state")
                 return False
 
             if self.cfg.front_dock:
@@ -308,7 +308,7 @@ class AutoDockStateMachine(AutoDockServer):
                     y_offset *= -1
                 _pose_list = []
 
-                # if robot y axis is way off, we will do parellel correction
+                # if robot y axis is way off, we will do parallel correction
                 # after this, will repeat predock
                 if abs(y_offset) > self.cfg.max_parallel_offset:
                     if not self.do_parallel_correction(y_offset):

--- a/autodock_sim/launch/tb3_nav_dock_sim.launch
+++ b/autodock_sim/launch/tb3_nav_dock_sim.launch
@@ -3,6 +3,7 @@
   <!-- Global param -->
   <arg name="autodock_server" default="true"/>
   <arg name="use_sim_time" default="true"/>
+  <arg name="debug_mode" default="true" doc="Use this to have aruco detections always ON (publish fiducial images always) and other useful visualization markers. Turn OFF for better performance in deployment."/>
 
   <!-- Spawn tb3 pose -->
   <arg name="x_pos" default="0.5"/>
@@ -17,6 +18,7 @@
   <group if="$(arg autodock_server)">
     <include file="$(find autodock_core)/launch/autodock_server.launch">
       <arg name="autodock_config" default="$(find autodock_examples)/configs/turtlebot3.yaml"/>
+      <arg name="debug_mode" value="$(arg debug_mode)" />
     </include>
   </group>
 


### PR DESCRIPTION
Hello!

This PR is adjacently related to [this issue](https://github.com/osrf/autodock/issues/4) that I reported. However it does not directly fix that. While I was debugging the issue, I found that the `aruco_detect` node was also consuming CPU when the autodock algorithm was idle. Screenshot of `htop` shown below shows `aruco_detect` CPU consumption when IDLE:

![aruco_consume_idle_before_fix](https://user-images.githubusercontent.com/62126032/167753434-4cbcc2f5-4740-4ab3-8d2a-2fba7a759f10.png)

Ideally, we should not be detecting/looking for aruco markers until an `AutoDock` action itself is started. But it seems like on default config, the `aruco_detect` is always on and looking for these markers resulting in high CPU consumption. Looking into this further, the `aruco_detect` node DOES have a neat service called [`/enable_detections`](https://github.com/UbiquityRobotics/fiducials/blob/1ae8a13d56fafa436aca181da451c1bf808a288c/aruco_detect/src/aruco_detect.cpp#L88) that lets us enable/disable detections. So without touching the source code for `aruco_detect`, we will be able to manage the state of these detections from the autodock node itself. 

This PR primarily helps implement this with the following changes:
1. [Add service client and utility function to set detections](https://github.com/osrf/autodock/commit/6239f987c0c733b313c504fff8f2eb9ad78b0dba)
2. [Set aruco detections based on autodock state](https://github.com/osrf/autodock/commit/3a4d141dcab04b58b5ae2bb87909f0cabcce65c8)

Some screenshots below from interactive testing with Turtlebot sim:
Below, you can see that `aruco_detect` consumption has reduced when the autodock is idle:

![aruco_consume_idle_after_fix](https://user-images.githubusercontent.com/62126032/167754490-4ec3b25f-6eb6-4e02-ad27-f7267053583d.png)

On startup itself, we disable detections so when the sim is launched with the `rviz`, we will NOT see any images from the `/fiducial_images` topic:

```
[INFO] [1652233347.443160, 0.000000]: Starting AutoDockServer Node
Enable detections response:  Disabled aruco detections.
```
![autodock_init_no_image](https://user-images.githubusercontent.com/62126032/167754537-1aba1478-77de-4c16-8f71-7e70f7d80bfe.png)

Below, you can see that `aruco_detect` is back to normal consumption when autodock is in progress:

![aruco_consume_running_afterfix](https://user-images.githubusercontent.com/62126032/167754589-92c8be5a-c360-43ff-8ac0-bdfd2ef67d8c.png)

Now we start seeing images on the `/fiducial_images` topic:

```
Enable detections response:  Enabled aruco detections.
[INFO] [1652233573.711246, 104.431000]: Will attempt with 1 retry
```

When autodock fails:

```
[ERROR] [1652233576.152186, 106.457000]: Not detecting two side markers, exit state
[WARN] [1652233576.159298, 106.460000]: Failed to Dock attempt
[WARN] [1652233576.163408, 106.467000]: Attempting retry: 1/1
[INFO] [1652233576.180853, 106.479000]: State is not retry-able
[WARN] [1652233576.187205, 106.482000]: Not able to retry
Enable detections response:  Disabled aruco detections.
[WARN] [1652233576.213065, 106.503000]:  State: [IDLE] | Failed execute Dock Action
```

![dock_called_image_but_Frozen](https://user-images.githubusercontent.com/62126032/167754629-0a833a82-d2bb-4b2f-9cb0-7b1f96f8d540.png)

When autodock succeeds:

```
[WARN] [1652233696.103499, 210.448000]:  State: [ACTIVATE_CHARGER] | Docked, activate charger!
[ INFO] [1652233696.111709104, 210.458000000]: ObstacleObserver received autodock state: 6
[WARN] [1652233698.406090, 212.458000]:  State: [ACTIVATE_CHARGER] | Celebration!!
[ INFO] [1652233698.411430833, 212.462000000]: ObstacleObserver received autodock state: 6
[WARN] [1652233698.411304, 212.461000]:  State: [IDLE] | All Success!
[ INFO] [1652233698.422862282, 212.472000000]: ObstacleObserver received autodock state: 1
Enable detections response:  Disabled aruco detections
```

![img_when_docking](https://user-images.githubusercontent.com/62126032/167754854-e598fa21-dd66-4ea6-b721-b55d62be8b3f.png)

Note that in `rviz`, once the docking action is complete, the image will look "frozen". That is because, we disable detections at the end of the action and `aruco_detect` will stop publishing to the `/fiducial_images` topic.

Points to ponder:
1. Currently the behavior is the detections are off on startup and are selectively enabled/disabled based on the dock state. Should there be an option to not do this when some sort of `debug` flag is passed for ease of debugging which in essence will turn off this feature and go back to previous default behavior?
2. There is now extra dependency on the `/enable_detections` service succeeding. In the event of failure of this service, we rely on the `Autodock` action's built-in retry mechanism to re-call the service instead of its own retry. I thought it was easier to keep track of the retries this way and conceptually consider that enabling/disabling detections is part of the docking algorithm itself.

